### PR TITLE
fix:encapsulating to escape empty-string-as-root instances

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -963,6 +963,32 @@ describe('Typeson', function () {
         }
     );
 
+    it(
+        'should round-trip with empty-string keys; typeson-registry issue #25',
+        function () {
+            const res = roundtrip({
+                '': new Date(1672018152309)
+            });
+            assert(res[''] instanceof Date, 'instanceof Date');
+            assert(res[''].getTime() === 1672018152309, 'Correct time');
+
+            const typeson = new Typeson().register({
+                set: {
+                    test (x) { return toStringTag(x) === 'Set'; },
+                    replace (st) {
+                        return [...st.values()];
+                    },
+                    revive (values) { return new Set(values); }
+                }
+            });
+
+            const tson = typeson.stringify({'': new Set()});
+            const result = typeson.parse(tson);
+
+            assert(result[''] instanceof Set);
+        }
+    );
+
     describe('Type error checking', () => {
         it('disallows hash type', () => {
             assert.throws(


### PR DESCRIPTION
fix: encapsulate to escape empty-string-as-root instances and revive in an empty-string-aware manner; fixes https://github.com/dfahlander/typeson-registry/issues/25

BREAKING CHANGE:

Empty string now may only reference root object when encapsulated and at top of `$: {}`