### PR TITLE
fix: distisnguish empty strings from whole document references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # typeson CHANGES
 
+## 8.0.0
+
+- BREAKING fix: empty string components of key paths are now escaped (as `''`)
+    and `''` is escaped as `''''`
+
 ## 7.0.2
 
 - fix: CJS export

--- a/README.md
+++ b/README.md
@@ -10,21 +10,52 @@ Preserves types over JSON, BSON or socket.io.
 const objs = [
   {foo: 'bar'},
   // {"foo":"bar"} (simple types gives plain JSON)
+
   {foo: new Date()},
   // {"foo":1464049031538, "$types":{"foo":"Date"}}
+
   {foo: new Set([new Date()])},
   // {"foo":[1464127925971], "$types":{"foo":"Set","foo.0":"Date"}}
+
   {foo: {sub: /bar/iu}},
   // {"foo":{"sub":{"source":"bar","flags":"i"}}, "$types":{"foo.sub":"RegExp"}}
+
   {foo: new Int8Array(3)},
   // {"foo":"AAAA", "$types":{"foo":"Int8Array"}}
+
   new Date(),
-  // {"$":1464128478593, "$types":{"$":{"":"Date"}}} (special format at root)
+  // {"$":1464128478593, "$types":{"$":{"":"Date"}}}
+  // Needs $ escaping for object at root and "" for whole object
+
   {$types: {}},
-  // {"$":{"$types":{}},"$types":true} (needs escaping)
-  {$types: {}, abc: new Date()}
+  // {"$":{"$types":{}},"$types":true}
+  // Needs $ escaping for special "$types"
+
+  {$types: {}, abc: new Date()},
   // {"$":{"$types":{},"abc":1672338131954},"$types":{"$":{"abc":"Date"}}}
+  // Needs $ escaping for special "$types"
+
+  {'': new Date(), "''": new Date()}
+  // {"":1672504445626,"''":1672504445626,"$types":{"''":"Date","''''":"Date"}}
+  // Needs escaping of empty string (as double astrophes) and escaping of double
+  //   apostrophes (doubled apostrophes)
 ];
+```
+
+Or a cyclic array:
+
+```js
+const arr = [];
+arr[0] = arr;
+// {"$":["#"],"$types":{"$":{"0":"#"}}}
+```
+
+Or a cyclic object:
+
+```js
+const obj = {};
+obj[''] = obj;
+// {"":"#","$types":{"''":"#"}}
 ```
 
 ## Why?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeson",
-  "version": "7.0.2",
+  "version": "8.0.0",
   "description": "Preserves types over JSON, BSON or socket.io",
   "main": "./dist/typeson-commonjs2.min.cjs",
   "browser": "./dist/typeson.umd.js",

--- a/test/test.js
+++ b/test/test.js
@@ -963,6 +963,39 @@ describe('Typeson', function () {
         }
     );
 
+    it(
+        'should round-trip with empty-string keys; typeson-registry issue #25',
+        function () {
+            const res = roundtrip({
+                '': new Date(1672018152309)
+            });
+            assert(res[''] instanceof Date, 'instanceof Date');
+            assert(res[''].getTime() === 1672018152309, 'Correct time');
+
+            // Check emptpy-string escape sequence itself
+            const res2 = roundtrip({
+                "''": new Date(1672018152309)
+            });
+            assert(res2["''"] instanceof Date, 'instanceof Date');
+            assert(res2["''"].getTime() === 1672018152309, 'Correct time');
+
+            const typeson = new Typeson().register({
+                set: {
+                    test (x) { return toStringTag(x) === 'Set'; },
+                    replace (st) {
+                        return [...st.values()];
+                    },
+                    revive (values) { return new Set(values); }
+                }
+            });
+
+            const tson = typeson.stringify({'': new Set()});
+            const result = typeson.parse(tson);
+
+            assert(result[''] instanceof Set);
+        }
+    );
+
     describe('Type error checking', () => {
         it('disallows hash type', () => {
             assert.throws(

--- a/utils/classMethods.js
+++ b/utils/classMethods.js
@@ -110,7 +110,11 @@ function isObject (v) {
  * @returns {string}
  */
 function escapeKeyPathComponent (keyPathComponent) {
-    return keyPathComponent.replace(/~/gu, '~0').replace(/\./gu, '~1');
+    return keyPathComponent.replaceAll(
+        "''", "''''"
+    ).replace(
+        /^$/u, "''"
+    ).replace(/~/gu, '~0').replace(/\./gu, '~1');
 }
 
 /**
@@ -119,7 +123,11 @@ function escapeKeyPathComponent (keyPathComponent) {
  * @returns {string}
  */
 function unescapeKeyPathComponent (keyPathComponent) {
-    return keyPathComponent.replace(/~1/gu, '.').replace(/~0/gu, '~');
+    return keyPathComponent.replace(/~1/gu, '.').replace(/~0/gu, '~').replace(
+        /^''$/u, ''
+    ).replaceAll(
+        "''''", "''"
+    );
 }
 
 /**


### PR DESCRIPTION
fix: distisnguish empty strings from whole document references; fixes https://github.com/dfahlander/typeson-registry/issues/25

BREAKING CHANGE:

Empty string keys are now escaped as `''` and `''` within keys are escaped as `''''`.

Also clarifies documents formats.

Alternative to #30 .