### PR TITLE
docs: Fix typo `Typeson.Promise`

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ As with `encapsulate` but automatically throws upon obtaining a `TypesonPromise`
 
 #### `encapsulateAsync` (obj, [opts])
 
-As with `encapsulate` but automatically throws upon obtaining a non-`TypesonPromise` return result from the replacer (as only a `Typeson-Promise` is expected for asynchronous types).
+As with `encapsulate` but automatically throws upon obtaining a non-`TypesonPromise` return result from the replacer (as only a `TypesonPromise` is expected for asynchronous types).
 
 ##### Sample
 

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ reconstructed).
 #### `TypesonPromise` class
 
 If you have a type which you wish to have resolved asynchronously, you
-can can return a `Typeson.Promise` (which works otherwise like a `Promise`)
+can can return a `TypesonPromise` (which works otherwise like a `Promise`)
 and call its first supplied argument (`resolve`) when ready.
 
 The reason we expect this class to be used here instead of regular `Promise`s
@@ -626,7 +626,7 @@ const typeson = new Typeson({sync: false}).register({
             return x instanceof MyAsync;
         },
         function (o) {
-            return new Typeson.Promise(function (resolve, reject) {
+            return new TypesonPromise(function (resolve, reject) {
                 setTimeout(function () {
                     // Do something more useful in real code
                     if (Date.now() % 2) {


### PR DESCRIPTION
`Typeson.Promise` (with a dot) is used in [README](https://github.com/dfahlander/typeson/blob/e4a4ed2/README.md#typesonpromise-class).