### PR TITLE
feat: add `encapsulateError` option for control of throwing properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The module `typeson-registry/presets/builtin` is 1.6 kb minified and gzipped and
 
 ## Limitations
 
-Since typeson has a synchronous API, it cannot encapsulate and revive async types such as `Blob`, `File` or `Observable`. Encapsulating an async object requires to be able to emit streamed content asynchronically. Remoting libraries could however complement typeson with a streaming channel that handles the emitting of stream content. For example, a remoting library could define a typeson rule that encapsulates an [Observable](https://github.com/zenparsing/es-observable) to an id (string or number for example), then starts subscribing to it and emitting the chunks to the peer as they arrive. The peer could revive the id to an observable that when subscribed to, will listen to the channel for chunks destinated to the encapsulated ID.
+typeson has synchronous and asynchronous APIs, but no streaming APIs, so for encapsulating and reviving async types such as `Blob`, `File` or `Observable` in a streaming manner one must be able to emit streamed content asynchronically. Remoting libraries could however complement typeson with a streaming channel that handles the emitting of stream content. For example, a remoting library could define a typeson rule that encapsulates an [Observable](https://github.com/zenparsing/es-observable) to an id (string or number for example), then starts subscribing to it and emitting the chunks to the peer as they arrive. The peer could revive the id to an observable that when subscribed to, will listen to the channel for chunks destinated to the encapsulated ID.
 
 ## Usage
 
@@ -250,6 +250,7 @@ Creates an instance of Typeson, on which you may configure additional types to s
 {
     cyclic?: boolean, // Default true to allow cyclic objects
     encapsulateObserver?: function, // Default no-op
+    encapsulateError?: function, // Optional ignore/substitute handler
     sync?: true, // Don't force a promise response regardless of type
     throwOnBadSyncType?: true // Default to throw when mismatch with `TypesonPromise` obtained for sync request or not returned for async
 }
@@ -287,6 +288,22 @@ The following properties are also present in particular cases:
 - `endIterateOwn` - Will be `true` if finishing iteration of "own" properties.
 - `endIterateUnsetNumeric` - Will be `true` if finishing iteration of unset numeric properties.
 - `end` - Convenience property that will be `true` if `endIterateIn`, `endIterateOwn`, or `endIterateUnsetNumeric` is `true`.
+
+###### `encapsulateError`: callback (see description)
+
+Called when a property access throws during encapsulation. The callback
+receives an object with:
+
+- `keypath` - The full keypath for the failing property.
+- `error` - The thrown error.
+- `parent` - The object or array containing the property.
+- `key` - The property key being read.
+- `stateObj` - The current state object.
+- `type` - The current detected type, if any.
+
+Return `{ignore: true}` to omit the property from the encapsulated result, or
+`{substitute: value}` to serialize a fallback value at that path instead.
+Throwing or returning nothing preserves the original error.
 
 ###### `sync`: boolean (Internal property)
 

--- a/test/test.js
+++ b/test/test.js
@@ -1884,6 +1884,170 @@ describe('Typeson', function () {
         });
     });
 
+    describe('encapsulateError', () => {
+        it('should ignore accessor errors when requested', () => {
+            const input = {
+                keep: 1,
+                inner: {}
+            };
+            Object.defineProperty(input.inner, 'boom', {
+                enumerable: true,
+                get () {
+                    throw new Error('baz');
+                }
+            });
+
+            /** @type {string[]} */
+            const paths = [];
+            const typeson = new Typeson({
+                encapsulateError (o) {
+                    paths.push(o.keypath);
+                    assert(o.keypath === 'inner.boom', 'Should report path');
+                    assert(o.key === 'boom', 'Should report property key');
+                    assert(
+                        o.error instanceof Error && o.error.message === 'baz',
+                        'Should report the thrown error'
+                    );
+                    return {ignore: true};
+                }
+            });
+
+            const result = typeson.encapsulate(input);
+            assert(result.keep === 1, 'Should keep unaffected properties');
+            assert(
+                result.inner && !Object.hasOwn(result.inner, 'boom'),
+                'Should omit the throwing property'
+            );
+            assert(
+                paths.length === 1 && paths[0] === 'inner.boom',
+                'Should invoke the handler once for the failing path'
+            );
+        });
+
+        it('should substitute accessor errors when requested', () => {
+            const input = {
+                inner: {}
+            };
+            Object.defineProperty(input.inner, 'boom', {
+                enumerable: true,
+                get () {
+                    throw new Error('baz');
+                }
+            });
+
+            const typeson = new Typeson({
+                encapsulateError (o) {
+                    assert(o.keypath === 'inner.boom', 'Should report path');
+                    return {substitute: `fallback:${o.keypath}`};
+                }
+            });
+
+            const result = typeson.encapsulate(input);
+            assert(
+                result.inner.boom === 'fallback:inner.boom',
+                'Should replace the failing property with the substitute'
+            );
+        });
+
+        it('should ignore accessor errors in arrays when requested', () => {
+            /** @type {unknown[]} */
+            const input = [];
+            Object.defineProperty(input, 'foo', {
+                enumerable: true,
+                get () {
+                    throw new Error('baz');
+                }
+            });
+
+            let called = false;
+            const typeson = new Typeson({
+                encapsulateError (o) {
+                    called = true;
+                    assert(o.keypath === 'foo', 'Should report array key');
+                    return {ignore: true};
+                }
+            });
+
+            const result = typeson.encapsulate(input);
+            assert(called, 'Should invoke the handler');
+            assert(Array.isArray(result), 'Should preserve the array result');
+            assert(!Object.hasOwn(result, 'foo'), 'Should omit the item');
+        });
+
+        it('should rethrow when the handler does not handle the error', () => {
+            const input = {
+                inner: {}
+            };
+            Object.defineProperty(input.inner, 'boom', {
+                enumerable: true,
+                get () {
+                    throw new Error('baz');
+                }
+            });
+
+            const typeson = new Typeson({
+                // @ts-expect-error Intentional bad handler result for test
+                encapsulateError () {
+                    return null;
+                }
+            });
+
+            assert.throws(
+                () => typeson.encapsulate(input),
+                /baz/u,
+                'Should preserve the original error when unhandled'
+            );
+        });
+
+        it(
+            'should rethrow when the handler returns an unsupported action',
+            () => {
+                const input = {
+                    inner: {}
+                };
+                Object.defineProperty(input.inner, 'boom', {
+                    enumerable: true,
+                    get () {
+                        throw new Error('baz');
+                    }
+                });
+
+                const typeson = new Typeson({
+                    // @ts-expect-error Intentional bad handler result for test
+                    encapsulateError () {
+                        return {unsupported: true};
+                    }
+                });
+
+                assert.throws(
+                    () => typeson.encapsulate(input),
+                    /baz/u,
+                    'Should preserve the original error for unknown responses'
+                );
+            }
+        );
+
+        it('should rethrow by default when a getter throws', () => {
+            const input = {
+                inner: {}
+            };
+            Object.defineProperty(input.inner, 'boom', {
+                enumerable: true,
+                get () {
+                    throw new Error('baz');
+                }
+            });
+
+            const typeson = new Typeson();
+
+            assert.throws(
+                () => typeson.encapsulate(input),
+                /baz/u,
+                'Should keep the original fail-fast behavior'
+            );
+        });
+    });
+
     describe('Iteration', function () {
         it('should allow `iterateIn`', () => {
             class A {

--- a/typeson.js
+++ b/typeson.js
@@ -222,6 +222,28 @@ function nestedPathsFirst (a, b) {
  */
 
 /**
+ * @typedef {object} EncapsulateErrorAction
+ * @property {boolean} [ignore]
+ * @property {any} [substitute]
+ */
+
+/**
+ * @typedef {object} EncapsulateErrorData
+ * @property {string} keypath
+ * @property {any} error
+ * @property {any} parent
+ * @property {string|Integer} key
+ * @property {StateObject} stateObj
+ * @property {string} type
+ */
+
+/**
+ * @callback EncapsulateErrorHandler
+ * @param {EncapsulateErrorData} data
+ * @returns {EncapsulateErrorAction|void}
+ */
+
+/**
  * @callback Observer
  * @param {KeyPathEvent|EndIterateInEvent|EndIterateOwnEvent|
  *   EndIterateUnsetNumericEvent|
@@ -244,6 +266,7 @@ function nestedPathsFirst (a, b) {
 * @property {number|boolean} [fallback] `true` sets to 0. Default is
 *  positive infinity. Used within `register`
 * @property {EncapsulateObserver} [encapsulateObserver]
+ * @property {EncapsulateErrorHandler} [encapsulateError]
 */
 
 /**
@@ -489,7 +512,7 @@ class Typeson {
         // Clone the object deeply while at the same time replacing any
         //   special types or cyclic reference:
         const cyclic = 'cyclic' in opts ? opts.cyclic : true;
-        const {encapsulateObserver} = opts;
+        const {encapsulateObserver, encapsulateError} = opts;
 
         /**
          *
@@ -690,6 +713,59 @@ class Typeson {
                     }, {type}));
                 }
                 : null;
+
+            /**
+             *
+             * @param {string} kp
+             * @param {any} error
+             * @param {any} parent
+             * @param {string|Integer} key
+             * @returns {any}
+             */
+            /**
+             *
+             * @param {string} kp
+             * @param {any} parent
+             * @param {string|Integer} key
+             * @returns {any}
+             */
+            const getEncapsulatedValue = (kp, parent, key) => {
+                try {
+                    return {
+                        value: _encapsulate(
+                            kp, parent[key], Boolean(_cyclic), _stateObj,
+                            promisesData, resolvingTypesonPromise
+                        )
+                    };
+                } catch (error) {
+                    if (!encapsulateError) {
+                        throw error;
+                    }
+                    const type = detectedType ?? _stateObj.type ??
+                        getJSONType(parent);
+                    const handled = encapsulateError({
+                        keypath: kp,
+                        error,
+                        parent,
+                        key,
+                        stateObj: _stateObj,
+                        type
+                    });
+                    if (!handled) {
+                        throw error;
+                    }
+                    if ('substitute' in handled) {
+                        return {
+                            value: handled.substitute,
+                            substitute: true
+                        };
+                    }
+                    if (handled.ignore) {
+                        return undefined;
+                    }
+                    throw error;
+                }
+            };
             if (['string', 'boolean', 'number', 'undefined'].includes(
                 $typeof
             )) {
@@ -834,16 +910,21 @@ class Typeson {
                         () => {
                             const kp = keypath + (keypath ? '.' : '') +
                                 escapeKeyPathComponent(key);
-                            const val = _encapsulate(
-                                kp, value[key], Boolean(_cyclic), _stateObj,
-                                promisesData, resolvingTypesonPromise
-                            );
+                            const encapsulatedValue =
+                                getEncapsulatedValue(kp, value, key);
+                            const val = encapsulatedValue &&
+                                encapsulatedValue.value;
                             if (hasConstructorOf(val, TypesonPromise)) {
                                 promisesData.push([
                                     kp, val, Boolean(_cyclic), _stateObj,
                                     clone, key, _stateObj.type
                                 ]);
-                            } else if (val !== undefined) {
+                            } else if (
+                                encapsulatedValue && (
+                                    val !== undefined ||
+                                    'substitute' in encapsulatedValue
+                                )
+                            ) {
                                 /** @type {{[key: (string|Integer)]: any}} */ (
                                     clone
                                 )[key] = val;
@@ -867,16 +948,21 @@ class Typeson {
                         _stateObj,
                         ownKeysObj,
                         () => {
-                            const val = _encapsulate(
-                                kp, value[key], Boolean(_cyclic), _stateObj,
-                                promisesData, resolvingTypesonPromise
-                            );
+                            const encapsulatedValue =
+                                getEncapsulatedValue(kp, value, key);
+                            const val = encapsulatedValue &&
+                                encapsulatedValue.value;
                             if (hasConstructorOf(val, TypesonPromise)) {
                                 promisesData.push([
                                     kp, val, Boolean(_cyclic), _stateObj,
                                     clone, key, _stateObj.type
                                 ]);
-                            } else if (val !== undefined) {
+                            } else if (
+                                encapsulatedValue && (
+                                    val !== undefined ||
+                                    'substitute' in encapsulatedValue
+                                )
+                            ) {
                                 /** @type {{[key: string]: any}} */ (
                                     clone
                                 )[key] = val;


### PR DESCRIPTION
feat: add `encapsulateError` option for control of throwing properties; fixes #29